### PR TITLE
Fix code scanning alert no. 15: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/org/cysecurity/cspf/jvl/controller/xxe.java
+++ b/src/main/java/org/cysecurity/cspf/jvl/controller/xxe.java
@@ -43,6 +43,9 @@ public class xxe extends HttpServlet {
         {
           InputStream xml=request.getInputStream();
           DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+          factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+          factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+          factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
           DocumentBuilder builder = factory.newDocumentBuilder();
           InputSource is = new InputSource(xml); 	
           Document doc = builder.parse(is);


### PR DESCRIPTION
Fixes [https://github.com/GorillaSecWebTeam/JavaVulnLabGHAS/security/code-scanning/15](https://github.com/GorillaSecWebTeam/JavaVulnLabGHAS/security/code-scanning/15)

To fix the problem, we need to configure the `DocumentBuilderFactory` to disable the parsing of external entities. This can be done by setting specific features on the factory to disallow DOCTYPE declarations and external entities. This will prevent the XML parser from resolving external entities, thus mitigating the risk of XXE attacks.

The changes should be made in the `processRequest` method where the `DocumentBuilderFactory` is instantiated. We need to set the following features on the factory:
- `http://apache.org/xml/features/disallow-doctype-decl` to `true`
- `http://xml.org/sax/features/external-general-entities` to `false`
- `http://xml.org/sax/features/external-parameter-entities` to `false`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
